### PR TITLE
Fix: Prevent duplicate workflow runs for @claude /full-review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,9 +36,9 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude /full-review')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fixed duplicate Claude workflow triggers when using `@claude /full-review`
- Added negative conditions to `claude.yml` to exclude `/full-review` comments

## Problem
When someone commented `@claude /full-review` on a PR, both workflows would trigger:
1. `claude.yml` (generic `@claude` handler)
2. `claude-code-review.yml` (specific `/full-review` handler)

This resulted in two separate review comments being posted.

## Solution
Added `!contains(...)` exclusion checks to the three comment-related trigger conditions in `claude.yml`:
- `issue_comment`
- `pull_request_review_comment`
- `pull_request_review`

Now the workflows are mutually exclusive:
- `@claude /full-review` → only triggers `claude-code-review.yml`
- `@claude` (any other text) → only triggers `claude.yml`

## Test plan
- [ ] Comment `@claude /full-review` on a PR and verify only one review is posted
- [ ] Comment `@claude` (without `/full-review`) and verify the generic workflow runs