### PR TITLE
Add testing feedback guidelines to reduce verbosity

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -111,8 +111,14 @@ jobs:
             6) Constructive Suggestions
                - Alternative approaches that might be cleaner
                - Opportunities to reduce complexity
-               - Missing test coverage for critical component behavior
                - Opportunities to improve accessibility
+
+            Testing Feedback Guidelines:
+            - **Be concise**: Avoid verbose test suggestions or lengthy code examples.
+            - **Stay laser-focused**: Only suggest tests that directly verify the specific changes in this PR—not tangential functionality.
+            - **Prioritize manual testing**: Brief, actionable suggestions for what to manually verify are most useful (e.g., "Test keyboard navigation on the new dropdown").
+            - **Limit scope**: If tests are needed, mention the scenario to cover in 1-2 sentences rather than writing full test implementations.
+            - **Skip if unnecessary**: Not every PR needs test suggestions—if the changes are straightforward or already covered, don't force test recommendations.
 
             Documentation & Storybook Review:
             - Determine if component behavior, props, or APIs have changed.


### PR DESCRIPTION
## Summary

- Adds a dedicated "Testing Feedback Guidelines" section to the Claude Code review prompt
- Addresses user feedback that test suggestions were sometimes too verbose or not laser-focused on specific PR changes
- Prioritizes manual testing suggestions (which users found useful) over lengthy code examples

## Changes

The new section includes guidance to:
- **Be concise**: Avoid verbose test suggestions or lengthy code examples
- **Stay laser-focused**: Only suggest tests that directly verify the specific changes in the PR
- **Prioritize manual testing**: Brief, actionable suggestions for what to manually verify
- **Limit scope**: Mention scenarios in 1-2 sentences rather than full test implementations
- **Skip if unnecessary**: Don't force test recommendations when changes are straightforward