### PR TITLE
Fix Claude trigger pattern and Codex post-comment job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/claude /full-review')
+      contains(github.event.comment.body, '@claude /full-review')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,10 +36,10 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude') && !contains(github.event.comment.body, '/claude /full-review')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/claude') && !contains(github.event.comment.body, '/claude /full-review')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/claude') && !contains(github.event.review.body, '/claude /full-review')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '/claude') || contains(github.event.issue.title, '/claude')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude /full-review')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/codex-comment.yml
+++ b/.github/workflows/codex-comment.yml
@@ -133,28 +133,34 @@ jobs:
     name: Post Codex reply
     runs-on: ubuntu-latest
     needs: run-codex
-    if: |
-      needs.run-codex.result == 'success' &&
-      needs.run-codex.outputs.final_message != ''
+    if: always() && needs.run-codex.result == 'success'
     permissions:
       issues: write
       pull-requests: write
     steps:
-      - name: Reply with Codex output
-        uses: actions/github-script@v7
+      - name: Debug outputs
+        run: |
+          echo "Final message length: ${#FINAL_MESSAGE}"
+          echo "Issue number: ${{ github.event.issue.number }}"
         env:
-          CODEX_FINAL_MESSAGE: ${{ needs.run-codex.outputs.final_message }}
+          FINAL_MESSAGE: ${{ needs.run-codex.outputs.final_message }}
+
+      - name: Reply with Codex output
+        if: needs.run-codex.outputs.final_message
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const body = process.env.CODEX_FINAL_MESSAGE;
-            if (!body) {
+            const body = `${{ needs.run-codex.outputs.final_message }}`;
+            if (!body || body.trim() === '') {
               core.info('No Codex output to post.');
               return;
             }
+            console.log('Posting comment with length:', body.length);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: ${{ github.event.issue.number }},
               body
             });
+            console.log('Comment posted successfully');


### PR DESCRIPTION
## Summary

This PR applies fixes learned from testing AI agent GitHub Actions in [zenml-io/gh-action-testing](https://github.com/zenml-io/gh-action-testing):

- **Claude workflows**: Change trigger pattern from `/claude` to `@claude`
  - The Claude Code Action uses tag mode by default and requires `@claude` mentions
  - Without this fix, the action logs show "No trigger was met for @claude" and skips
  
- **Codex post-comment job**: Fix multiline output handling issues
  - Use `always() && needs.run-codex.result == 'success'` for more reliable job evaluation
  - Move empty message check to step level
  - Use template literals instead of env vars for multiline content
  - Use explicit `${{ github.event.issue.number }}` instead of `context.issue.number`
  - Add debug step for troubleshooting

## Test plan

- [ ] Trigger Claude with `@claude Say hello!` on a PR
- [ ] Trigger Claude full review with `@claude /full-review` on a PR
- [ ] Trigger Codex with `/codex Say hello!` on a PR
- [ ] Verify post-comment job posts the response correctly